### PR TITLE
Update docs for UQM 0.8.0 content package

### DIFF
--- a/README
+++ b/README
@@ -14,6 +14,7 @@ platform, please see:
   INSTALL.macosx   for MacOS X build instructions
   INSTALL.symbian  for Symbian build instructions
   doc/users/unixinstall
+  doc/devel/content-editing for modifying the content packages
 
 The home page of the project is located at http://sc2.sourceforge.net/
 You can find links to downloads, our bug database, and our forum there.

--- a/doc/devel/content-editing
+++ b/doc/devel/content-editing
@@ -1,0 +1,26 @@
+This document describes how to make quick edits to the content
+packages used by The Ur-Quan Masters.
+
+1. Extract the package
+----------------------
+The content is distributed in `.uqm` archives. These are ordinary ZIP
+files. Use `unzip` to extract them:
+
+    unzip uqm-0.8.0-content.uqm -d tmp
+
+This creates a directory `tmp` with the package contents.
+
+2. Modify the files
+-------------------
+Edit the extracted files as needed. For example, you might change text
+in `base/gamestrings.txt`.
+
+3. Repack the archive
+---------------------
+When your changes are complete, recreate the archive with `zip`:
+
+    cd tmp
+    zip -r ../uqm-0.8.0-content.uqm .
+
+Copy the resulting `uqm-0.8.0-content.uqm` back to
+`content/packages/` so the game can use your modified content.

--- a/doc/users/unixinstall
+++ b/doc/users/unixinstall
@@ -9,10 +9,10 @@ They are listed in the file INSTALL in the top dir.
 2.
 If you haven't done so already, download the content .uqm files packages
 that you want, from where you got this source package.
-You'll need uqm-0.7.0-content.uqm; uqm-0.7.0-3domusic.uqm (music from the 3DO
-version) and uqm-0.7.0-voice.uqm (spoken alien dialogs) are optional.
+You'll need uqm-0.8.0-content.uqm; uqm-0.8.0-3domusic.uqm (music from the 3DO
+version) and uqm-0.8.0-voice.uqm (spoken alien dialogs) are optional.
 
-Put the uqm-0.7.0-content.uqm in the directory content/packages/ which exists
+Put the uqm-0.8.0-content.uqm in the directory content/packages/ which exists
 in the top directory of the source tree (the dir with (among others)
 COPYING, src/, and build.var.in).
 Put the optional music and voice packages in the content/addons/ directory.


### PR DESCRIPTION
## Summary
- reference 0.8.0 content package in Unix install instructions
- document how to edit `.uqm` packages
- link the new doc from README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6851f2f6ff908331bce96a10ad7164e7